### PR TITLE
channels setup for server and cli to talk with node_state

### DIFF
--- a/kademlia/kademlia.go
+++ b/kademlia/kademlia.go
@@ -1,22 +1,33 @@
 package kademlia
 
-import "crypto/sha1"
+import (
+	"crypto/sha1"
+	"program/kademlia/msg"
+	"strconv"
+	"strings"
+)
 
 const alpha = 3
 const k = 20
 
 type Kademlia struct {
 	routingTable RoutingTable
-	valueMap  map[string][]byte
-	network Network
+	valueMap     map[string][]byte
+	network      Network
 }
 
-func NewKademlia(me Contact) *Kademlia{
+func NewKademlia(me Contact, ch chan msg.RPC) *Kademlia {
 	kademlia := &Kademlia{}
 	rt := NewRoutingTable(me)
 	kademlia.routingTable = *rt
-	network := &Network{}
+	network := &Network{
+		Self:    me.Address,
+		RecvRPC: ch,
+	}
 	kademlia.network = *network
+	n := strings.Index(me.Address, ":")
+	port, _ := strconv.Atoi(me.Address[n+1:])
+	go kademlia.network.Listen("0.0.0.0", port)
 	valueMap := make(map[string][]byte)
 	kademlia.valueMap = valueMap
 	return kademlia
@@ -32,14 +43,12 @@ func (kademlia *Kademlia) LookupContact(target *Contact) {
 }
 
 // KClosestNodes Finds the k closest nodes to the target
-func (kademlia *Kademlia) KClosestNodes(target *Contact) []Contact{
+func (kademlia *Kademlia) KClosestNodes(target *Contact) []Contact {
 	closestContacts := kademlia.routingTable.FindClosestContacts(target.ID, k)
 	return closestContacts
 }
 
-
-
-func (kademlia *Kademlia) LookupData(hash string) []byte{
+func (kademlia *Kademlia) LookupData(hash string) []byte {
 
 	//fmt.Println("map:", string(kademlia.valueMap[hash]))
 	return kademlia.valueMap[hash]
@@ -48,7 +57,7 @@ func (kademlia *Kademlia) LookupData(hash string) []byte{
 func (kademlia *Kademlia) Store(data []byte) {
 	// https://gobyexample.com/sha1-hashes
 	// https://gobyexample.com/maps
-	key :=  sha1.New()
+	key := sha1.New()
 	key.Write(data)
 	var id = string(key.Sum(nil))
 	kademlia.valueMap[id] = data

--- a/kademlia/msg/msg.go
+++ b/kademlia/msg/msg.go
@@ -7,22 +7,8 @@ import (
 
 //TODO add kademlia id
 type RPC struct {
-	RPC string
-	//uuid *uuid.UUID
+	RPC     string
 	Address string
-}
-
-func MakePong(address string) []byte {
-	pong := &RPC{
-		RPC:     "PONG",
-		Address: address,
-	}
-	data, err := json.Marshal(pong)
-	if err != nil {
-		fmt.Println(err)
-		return nil
-	}
-	return data
 }
 
 func TestRPC(x interface{}) bool {
@@ -37,12 +23,24 @@ func TestRPC(x interface{}) bool {
 }
 
 func MakePing(address string) []byte {
-	//u, _ := uuid.NewV4()
 	ping := &RPC{
 		RPC:     "PING",
 		Address: address,
 	}
 	data, err := json.Marshal(ping)
+	if err != nil {
+		fmt.Println(err)
+		return nil
+	}
+	return data
+}
+
+func MakePong(address string) []byte {
+	pong := &RPC{
+		RPC:     "PONG",
+		Address: address,
+	}
+	data, err := json.Marshal(pong)
 	if err != nil {
 		fmt.Println(err)
 		return nil

--- a/kademlia/msg/msg_test.go
+++ b/kademlia/msg/msg_test.go
@@ -27,5 +27,5 @@ func TestDecodeRPC(t *testing.T) {
 		t.Error("Struct not viable")
 	}
 	decoded := DecodeRPC(data)
-	assert.True(t, TestRPC(decoded), "TestDecodeRPC()")
+	assert.True(t, TestRPC(decoded), "DecodeRPC() error")
 }

--- a/kademlia/run.go
+++ b/kademlia/run.go
@@ -1,0 +1,41 @@
+package kademlia
+
+import (
+	"fmt"
+	"program/kademlia/msg"
+	"program/udp"
+	"strings"
+)
+
+func Run(state Kademlia, cliCh chan string) {
+	for {
+		select {
+		case recv, serverChStatus := <-state.network.RecvRPC:
+			if serverChStatus {
+				switch recv.RPC {
+				case "PING":
+					fmt.Println(recv)
+					udp.Client(recv.Address, msg.MakePong(state.network.Self))
+				case "PONG":
+					fmt.Println(recv)
+				}
+			} else {
+				fmt.Println("Channel closed")
+			}
+		default:
+			//idk
+		}
+		select {
+		case cliInst, cliChStatus := <-cliCh:
+			if cliChStatus {
+				n := strings.Index(cliInst, "|")
+				reciever := NewContact(NewRandomKademliaID(), cliInst[n+1:])
+				state.network.SendPingMessage(&reciever)
+			} else {
+				fmt.Println("Channel closed")
+			}
+		default:
+			//idk
+		}
+	}
+}

--- a/udp/client.go
+++ b/udp/client.go
@@ -1,28 +1,18 @@
 package udp
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
 	"net"
 )
 
 //https://stackoverflow.com/questions/26028700/write-to-client-udp-socket-in-go
 
-func Client(address string, msg string) {
-	buffer := make([]byte, 2048)
+func Client(address string, msg []byte) {
 	conn, err := net.Dial("udp", address)
 	if err != nil {
 		fmt.Printf("Some error %v", err)
 		return
 	}
-	fmt.Fprintf(conn, msg)
-	_, err = bufio.NewReader(conn).Read(buffer)
-	if err == nil {
-		n := bytes.IndexByte(buffer[:], 0)
-		fmt.Printf("%s\n", string(buffer[:n]))
-	} else {
-		fmt.Printf("Some error %v\n", err)
-	}
+	conn.Write(msg)
 	conn.Close()
 }


### PR DESCRIPTION
Added two channels one for the CLI to talk to the node state (run.go) and also one for the server (network.go, listen(ip,port)) to talk to the state. So right now the three threads talk like this(the direction of the arrows denote the msg direction):

CLI -> node_state <- server

CLI could be made to not need a channel but as it stands all the fields in the kademlia object is private and cannot be called in the CLI.