### PR TITLE
msg_test fixes, altering the struct makes the test fail

### DIFF
--- a/kademlia/msg/msg.go
+++ b/kademlia/msg/msg.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 )
 
-//TODO add kademlia id
+//If a field is added make sure all the test works afterwards,
+//should be fixed by adding the empty field of the new field to the test json object
 type RPC struct {
 	RPC     string
 	Address string
-	Key string
-	Value string
+	Key     string
+	Value   string
 }
 
 func TestRPC(x interface{}) bool {

--- a/kademlia/msg/msg_test.go
+++ b/kademlia/msg/msg_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestMakePing(t *testing.T) {
 	formatted := MakePing("12.34.56.78:1234")
-	correct := []byte("{\"RPC\":\"PING\",\"Address\":\"12.34.56.78:1234\"}")
+	correct := []byte("{\"RPC\":\"PING\",\"Address\":\"12.34.56.78:1234\",\"Key\":\"\",\"Value\":\"\"}")
 	assert.Equal(t, formatted, correct, "MakePing() error")
 }
 
 func TestMakePong(t *testing.T) {
 	formatted := MakePong("12.34.56.78:1234")
-	correct := []byte("{\"RPC\":\"PONG\",\"Address\":\"12.34.56.78:1234\"}")
+	correct := []byte("{\"RPC\":\"PONG\",\"Address\":\"12.34.56.78:1234\",\"Key\":\"\",\"Value\":\"\"}")
 	assert.Equal(t, formatted, correct, "MakePong() error")
 }
 

--- a/kademlia/network.go
+++ b/kademlia/network.go
@@ -43,8 +43,8 @@ func (network *Network) decode(data []byte) {
 }
 
 func (network *Network) SendPingMessage(contact *Contact) {
-	msg := msg.MakePing(contact.Address)
-	udp.Client(contact.Address, msg)
+	message := msg.MakePing(contact.Address)
+	udp.Client(contact.Address, message)
 }
 
 func (network *Network) SendFindContactMessage(contact *Contact) {


### PR DESCRIPTION
When altering the struct the tests TestMakePong() and TestMakePing() fail, empty fields needs to be added to the bytes arrays correct in those to tests