### PR TITLE
cli exit and debug commands

### DIFF
--- a/cmd/cli/cli.go
+++ b/cmd/cli/cli.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"program/udp"
+	"strings"
+)
+
+func CLI(cliCh chan string) {
+	reader := bufio.NewReader(os.Stdin)
+	run := true
+	//cli loop
+	for run {
+		text, _ := reader.ReadString('\n')
+		switch strings.Replace(text, "\n", "", -1) {
+		case "self":
+			fmt.Printf("%v\n", udp.GetOutboundIP())
+		case "exit":
+			run = false
+		case "ping":
+			fmt.Print("Address: ")
+			address, _ := reader.ReadString('\n')
+			address = strings.Replace(address, "\n", "", -1)
+			cliCh <- "ping|" + address
+		case "find closest":
+			cliCh <- "find closest|"
+		case "print buckets":
+			cliCh <- "print buckets|"
+		case "add contact":
+			fmt.Print("Address: ")
+			address, _ := reader.ReadString('\n')
+			address = strings.Replace(address, "\n", "", -1)
+			cliCh <- "add contact|" + address
+		case "put":
+			fmt.Print("Enter text to store: ")
+			data, _ := reader.ReadString('\n')
+			data = strings.Replace(data, "\n", "", -1)
+			if len(data) < 256 {
+				cliCh <- "put|" + data
+			} else {
+				fmt.Println("Text was to long to be stored (255 characters max)")
+			}
+		case "map":
+			cliCh <- "map|"
+		case "debug":
+			cliCh <- "debug|"
+		default:
+			fmt.Printf("Not a command\n")
+		}
+	}
+}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,13 +1,10 @@
 package main
 
 import (
-	"bufio"
-	"fmt"
-	"os"
+	"program/cmd/cli"
 	k "program/kademlia"
 	"program/kademlia/msg"
 	"program/udp"
-	"strings"
 )
 
 func main() {
@@ -24,44 +21,6 @@ func main() {
 	node := k.NewKademlia(me, serverCh)
 	//start the node state thread
 	go k.Run(*node, cliCh)
-	//start the cli reader
-	reader := bufio.NewReader(os.Stdin)
-	run := true
-	//cli loop
-	for run {
-		text, _ := reader.ReadString('\n')
-		switch strings.Replace(text, "\n", "", -1) {
-		case "self":
-			fmt.Printf("%v\n", udp.GetOutboundIP())
-		case "terminate":
-			run = false
-		case "ping":
-			fmt.Print("Address: ")
-			address, _ := reader.ReadString('\n')
-			address = strings.Replace(address, "\n", "", -1)
-			cliCh <- "ping|" + address
-		case "find closest":
-			cliCh <- "find closest|"
-		case "print buckets":
-			cliCh <- "print buckets|"
-		case "add contact":
-			fmt.Print("Address: ")
-			address, _ := reader.ReadString('\n')
-			address = strings.Replace(address, "\n", "", -1)
-			cliCh <- "add contact|" + address
-		case "put":
-			fmt.Print("Enter text to store: ")
-			data, _ := reader.ReadString('\n')
-			data = strings.Replace(data, "\n", "", -1)
-			if len(data) < 256 {
-				cliCh <- "put|" + data
-			} else {
-				fmt.Println("Text was to long to be stored (255 characters max)")
-			}
-		case "map":
-			cliCh <- "map|"
-		default:
-			fmt.Printf("Not a command\n")
-		}
-	}
+	//start the cli
+	cli.CLI(cliCh)
 }

--- a/kademlia/run.go
+++ b/kademlia/run.go
@@ -23,6 +23,7 @@ func Run(state Kademlia, cliCh chan string) {
 		state.convIDMap[*convID] = *joinlookup
 		state.network.SendFindContactMessage(&public, *convID, *myid)
 	}
+	debug := false
 	for {
 		select {
 		case recv, serverChStatus := <-state.network.RecvRPC:
@@ -31,12 +32,15 @@ func Run(state Kademlia, cliCh chan string) {
 				have the sender added to routing table*/
 				conid := NewSha1KademliaID([]byte(recv.Address))
 				state.routingTable.AddContact(NewContact(conid, recv.Address))
+				if debug {
+					fmt.Println(recv)
+				}
 				switch recv.RPC {
 				case "PING":
-					reciever := NewContact(NewSha1KademliaID([]byte(recv.Address)), recv.Address)
-					state.network.SendPingMessage(&reciever)
+					data := msg.MakePong(state.network.Self, recv.ConvID)
+					udp.Client(recv.Address, data)
 				case "PONG":
-					fmt.Println(recv)
+					//Idk
 				case "FIND_CONTACT":
 					//Find the k closest nodes and send them back
 					kadID := NewKademliaID(recv.TargetID)
@@ -113,7 +117,6 @@ func Run(state Kademlia, cliCh chan string) {
 					}
 
 				case "STORE":
-					//fmt.Println(recv)
 					state.Store(recv.StoreValue)
 				}
 			} else {
@@ -154,6 +157,8 @@ func Run(state Kademlia, cliCh chan string) {
 					state.LookupContact(storeTarget, *convID)
 				case "map":
 					fmt.Println(state.valueMap)
+				case "debug":
+					debug = !debug
 				default:
 					fmt.Println("Unknown command")
 				}


### PR DESCRIPTION
Code refractoring added debug command which toggles run.go to print everything received from server, exit which terminates the node.